### PR TITLE
fix: unit action will duplicate scores corrently and assigned units l…

### DIFF
--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -111,7 +111,7 @@
                 {{ unit }} -
                 {{
                   units.find((u) => u.value.toString() === unit.toString())
-                    ?.unit_name
+                    ?.label
                 }}
               </div>
             </div>


### PR DESCRIPTION
fixed the issue causing the unit scores to be copied with all assessment_ranks stored against one assessment_criterion

fixed assigned units names not showing up on account page